### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG tag='latest'
+FROM docker.greenkeytech.com/base:$tag
+
+COPY . /fastText
+
+WORKDIR /fastText
+RUN make -j `cat /proc/cpuinfo | grep -c processor`
+


### PR DESCRIPTION
This PR adds a simple Dockerfile to copy resources from instead of the local filesystem. This will build the `fasttext` module but leaves the python install for later in the build pipeline. 